### PR TITLE
Fix data_store_file.h bug

### DIFF
--- a/includes/data_store_file.h
+++ b/includes/data_store_file.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <iostream>
 #include <vector>
+#include <fstream>
+
 #include "../includes/data_store.h"
 #include "string_data.h"
 


### PR DESCRIPTION
```cpp
#include <fstream>
```

Needs to be in data_store_file.h so that we can access file stream functions.